### PR TITLE
fix: too long titlebar text wraps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ nice is an easy to use, highly configurable extension for **[Awesome WM](https:/
 
 ### Prerequisites 
 
-* You need to be using **[Awesome WM](https://awesomewm.org/)** as your window manager, and should already have a working basic configuration file. I have developed and tested nice only on **awesome v4.3 git version**
+* You need to be using **[Awesome WM](https://awesomewm.org/)** as your window manager. Currently nice only works with **awesome v4.3 git version**. I am working on support for the stable release.
 
-* I **highly** suggest using a compositor such as **[picom](https://github.com/yshui/picom)**. My recommended shadow settings are given below
+* I **highly** recommend using a compositor such as **[picom](https://github.com/yshui/picom)**. My recommended shadow settings are given below
 
   ```
   shadow = true;
@@ -155,7 +155,10 @@ nice will automatically detect and change the window decoration color to match t
 
 ## Issues
 
-If you face any bugs or issues (or have a feature request), please feel free to open an issue on here
+If you face any bugs or issues (or have a feature request), please feel free to open an issue.
+
+### Known Issues
+  * Error: `Typelib file for namespace 'Gdk' (any version) not found` on NixOS. [Recommended fix can be found here](https://github.com/mut-ex/awesome-wm-nice/issues/1#issuecomment-684427129)
 
 
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ $ git clone https://github.com/mut-ex/awesome-wm-nice.git nice
 
 ## Usage
 
+First of all, make sure that you do not already have code in place that requests for the default titlebars. Something like this
+
+```lua
+client.connect_signal("request::titlebars", function(c) ... end)
+```
+
 To use nice, you first need to load the module. You can do so by placing the following line right after `beautiful.init(...)`
 
 ```lua
@@ -64,6 +70,21 @@ If you are fine using the default configuration, you are all done! However if yo
 ```lua
 local nice = require("nice")
 nice = {
+  --[[
+    For parameters that take a table, you only need to pass the
+    values you intend to change.
+    
+    For example:
+    
+    titlebar_items = {
+      left = {"close"}
+    }
+
+    tooltip_messages = {
+      close = "Destroy this client!"
+    }
+  ]]
+
   -- * == Titlebar specific == *
   -- titlebar_color = "#1E1E24"
   -- titlebar_height = 38
@@ -141,6 +162,3 @@ If you face any bugs or issues (or have a feature request), please feel free to 
 ## License
 
 [![License](http://img.shields.io/:license-mit-blue.svg)](http://doge.mit-license.org)
-
-
-

--- a/colors.lua
+++ b/colors.lua
@@ -7,7 +7,6 @@ local max = math.max
 local min = math.min
 local pow = math.pow
 local random = math.random
-local debug = require("helpers").debug
 
 -- Returns a value that is clipped to interval edges if it falls outside the interval
 local function clip(num, min_num, max_num) return

--- a/init.lua
+++ b/init.lua
@@ -451,8 +451,9 @@ local function create_titlebar_title(c)
         opacity = c.active and 1 or title_unfocused_opacity,
         valign = "center",
         widget = textbox,
-
     }
+
+    local titlebar_font = _private.titlebar_font or "IBM Plex Sans 11"
     local function update()
         local text_color = is_contrast_acceptable(
                                title_color_light, client_color) and
@@ -460,8 +461,9 @@ local function create_titlebar_title(c)
 
         title_widget.markup =
             ("<span foreground='%s' font='%s'>%s</span>"):format(
-                text_color, _private.titlebar_font or "IBM Plex Sans 11", c.name)
+                text_color, titlebar_font, c.name)
     end
+
     c:connect_signal("property::name", update)
     -- c:connect_signal("property::_nice_color", update)
     c:connect_signal(
@@ -470,7 +472,18 @@ local function create_titlebar_title(c)
         end)
     c:connect_signal("focus", function() title_widget.opacity = 1 end)
     update()
-    return {title_widget, widget = wcontainer.margin, left = 4, right = 4}
+
+    local titlebar_font_size = tonumber(titlebar_font:gsub('[^0-9]', ''))
+    local verticalMargin = (_private.titlebar_height - titlebar_font_size) / 2
+
+    return {
+        title_widget,
+        widget = wcontainer.margin,
+        left = 4,
+        right = 4,
+        top = verticalMargin,
+        bottom = verticalMargin,
+    }
 end
 
 -- Creates titlebar items for a given group of item names


### PR DESCRIPTION
fixes #5 

![image](https://user-images.githubusercontent.com/17091659/92060601-9a580f00-ed6a-11ea-8d0e-e5424184779e.png)
