### PR TITLE
Allow Nice to be outside of package directory root

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -63,13 +63,13 @@ local pixbuf_get_from_window = gdk.pixbuf_get_from_window
 -- => nice
 -- ============================================================
 -- Colors
-local colors = require("nice.colors")
+local colors = require(... .. ".colors")
 local color_darken = colors.darken
 local color_lighten = colors.lighten
 local is_contrast_acceptable = colors.is_contrast_acceptable
 local relative_luminance = colors.relative_luminance
 -- Shapes
-local shapes = require("nice.shapes")
+local shapes = require(... .. ".shapes")
 local create_corner_top_left = shapes.create_corner_top_left
 local create_edge_left = shapes.create_edge_left
 local create_edge_top_middle = shapes.create_edge_top_middle
@@ -173,7 +173,7 @@ _private.sticky_color = "#f6a2ed"
 -- => Saving and loading of color rules
 -- ============================================================
 local table = table
-local t = require("nice.table")
+local t = require(... .. ".table")
 table.save = t.save
 table.load = t.load
 

--- a/shapes.lua
+++ b/shapes.lua
@@ -3,7 +3,7 @@
 -- ============================================================
 --
 local lgi = require("lgi")
-local colors = require("nice.colors")
+local colors = require(tostring(...):match(".*nice") .. ".colors")
 local hex2rgb = colors.hex2rgb
 local darken = colors.darken
 local cairo = lgi.cairo


### PR DESCRIPTION
Requiring nice with `require("some.path.to.nice")` will now work as all internal require calls will no longer assume `nice` is at the root of the package paths. In the previous example, internal modules will be required as `some.path.to.nice.colors`, for example.

I did this because I add all external dependencies under a `vendor/` directory in my Awesome config to keep things structured.

```
config/awesome
  theme/
  modules/
  …
  vendor/
    nice/
    …
```

With this change in place I can require and use the project. (I also have applied the fix in #24 on my `master` so I can actually use it, I'm not using only this PR branch in my config.)